### PR TITLE
SC-1998: Automatic roles setup at login in superset

### DIFF
--- a/roles/commcare_analytics/defaults/main.yml
+++ b/roles/commcare_analytics/defaults/main.yml
@@ -50,6 +50,8 @@ superset_oauth_providers:
 superset_auth_user_registration: TRUE
 # default role when user self registers
 superset_auth_user_registration_role: Admin
+# Re-evaluate user's roles at each login
+superset_sync_roles_at_login: True
 
 
 postgresql_version: 12

--- a/roles/commcare_analytics/defaults/main.yml
+++ b/roles/commcare_analytics/defaults/main.yml
@@ -5,7 +5,7 @@ base_python_package: "python3"
 
 apt_update_cache: yes
 
-ssl_enabled: no
+ssl_enabled: false
 app_name: commcare_analytics
 app_user: "{{ vault_ansible_user }}"
 home_dir: /home/{{ app_user }}
@@ -23,7 +23,7 @@ log_dir: "{{ base_dir }}/log"
 
 # superset defaults
 superset_enabled: yes
-superset_ssl_enabled: no
+superset_ssl_enabled: false
 superset_db_name: "superset"
 superset_project_dir: "{{ base_dir }}/superset"
 superset_virtualenv_dir: "{{ base_dir }}/.virtualenvs/superset"
@@ -47,11 +47,11 @@ superset_auth_type: AUTH_DB
 superset_oauth_providers:
 
 # allow user self registration
-superset_auth_user_registration: TRUE
+superset_auth_user_registration: true
 # default role when user self registers
 superset_auth_user_registration_role: Admin
 # Re-evaluate user's roles at each login
-superset_sync_roles_at_login: True
+superset_auth_roles_sync_at_login: true
 
 
 postgresql_version: 12
@@ -79,7 +79,7 @@ gunicorn_timeout_seconds: 30
 nginx_access_log_file: "{{ log_dir }}/nginx.access.log"
 nginx_error_log_file: "{{ log_dir }}/nginx.error.log"
 
-certbot_auto_renew: yes
+certbot_auto_renew: true
 certbot_script: /opt/certbot-auto
 certbot_dir: /etc/letsencrypt
 certbot_admin_email: admin@example.com

--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -80,7 +80,7 @@ OAUTH_PROVIDERS = [
 AUTH_USER_REGISTRATION_ROLE = '{{ superset_auth_user_registration_role }}'
 # Enable automatic creation of user account after first time oauth is done successfully
 AUTH_USER_REGISTRATION = {{ superset_auth_user_registration }}
-# If we should replace ALL the user's roles each login, or only on registration
+# If true, we replace ALL the user's roles each login. If false, we create the roles on registration
 AUTH_ROLES_SYNC_AT_LOGIN = {{ superset_sync_roles_at_login }}
 
 CUSTOM_SECURITY_MANAGER = CustomSecurityManager

--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -81,6 +81,6 @@ AUTH_USER_REGISTRATION_ROLE = '{{ superset_auth_user_registration_role }}'
 # Enable automatic creation of user account after first time oauth is done successfully
 AUTH_USER_REGISTRATION = {{ superset_auth_user_registration }}
 # If true, we replace ALL the user's roles each login. If false, we create the roles on registration
-AUTH_ROLES_SYNC_AT_LOGIN = {{ superset_sync_roles_at_login }}
+AUTH_ROLES_SYNC_AT_LOGIN = {{ superset_auth_roles_sync_at_login }}
 
 CUSTOM_SECURITY_MANAGER = CustomSecurityManager

--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -78,7 +78,9 @@ OAUTH_PROVIDERS = [
 
 # The default user self registration role
 AUTH_USER_REGISTRATION_ROLE = '{{ superset_auth_user_registration_role }}'
-# Will allow user self registration
+# Enable automatic creation of user account after first time oauth is done successfully
 AUTH_USER_REGISTRATION = {{ superset_auth_user_registration }}
+# If we should replace ALL the user's roles each login, or only on registration
+AUTH_ROLES_SYNC_AT_LOGIN = {{ superset_sync_roles_at_login }}
 
 CUSTOM_SECURITY_MANAGER = CustomSecurityManager


### PR DESCRIPTION
Partial code changes for SC-1998

Adding configuration setting that enables re-evaluation of roles associated with a superset user during each login. Roles info is updated based on domain membership in HQ for the same user.