### PR TITLE
Kill all the gunicorn processes correctly

### DIFF
--- a/roles/commcare_analytics/templates/superset/superset_supervisor_config.j2
+++ b/roles/commcare_analytics/templates/superset/superset_supervisor_config.j2
@@ -5,6 +5,7 @@ command = {{ superset_virtualenv_dir }}/bin/superset_start
 user = {{ ansible_user }}
 stdout_logfile = {{ log_dir }}/superset.log
 stderr_logfile = {{ log_dir }}/superset.log
+stopasgroup = true
 
 ; disabling supervisor default log rotation feature as it renaming 
 ; and recreating the log file. Due to which we are running into file permission issues.


### PR DESCRIPTION
Currently supervisor is not killing the gunicorn processes correctly, even though it reports that the processes are stopped, they are still running in the background. This was causing 504s from nginx.

With this option, all the child processes from that command get stopped.

@akashkj @proteusvacuum @kaapstorm 