### PR TITLE
Add French as a language option

### DIFF
--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -103,4 +103,5 @@ CELERY_CONFIG = CeleryConfig
 LANGUAGES = {
    'en': {'flag':'us', 'name':'English'},
    'pt': {'flag':'pt', 'name':'Portuguese'}
+   'fr': {'flag':'fr', 'name':'French'}
 }

--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -50,7 +50,10 @@ FEATURE_FLAGS = {
     "DASHBOARD_NATIVE_FILTERS": True,
     "DASHBOARD_NATIVE_FILTERS_SET": True,
     "DASHBOARD_FILTERS_EXPERIMENTAL": True,
+    "ENABLE_JAVASCRIPT_CONTROLS": True,
+    "ENABLE_TEMPLATE_PROCESSING": True
 }
+
 
 
 # This is where async UCR imports are stored temporarily


### PR DESCRIPTION
I already added this to the config file running on prod, so we don't have to run the playbook. Superset's French language is pretty populated, so we don't have to maintain its language files