### PR TITLE
pre-commit hook for unencrypted vault files

### DIFF
--- a/git-hooks/install.sh
+++ b/git-hooks/install.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+function usage()
+{
+    cat << EOF
+usage: $0 options
+
+This script installs git hooks
+
+OPTIONS:
+   -h      Show this message
+   -f      don't ask before overwriting your current git hooks
+   -r      remove existing hooks but do not add the new ones
+EOF
+}
+
+OPT='-i'
+FUNC='link_hooks'
+
+while getopts "hfr" OPTION
+do
+    case $OPTION in
+        h)
+            usage
+            exit
+            ;;
+        f)
+            OPT='-f'
+            ;;
+        r)
+            FUNC='remove_hooks'
+            ;;
+        ?)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+function link_hooks() {
+    hook=$1
+    base_path=$2
+    ln -s -f $OPT ../../git-hooks/$hook.sh $base_path/hooks/$hook
+}
+
+function remove_hooks() {
+    hook=$1
+    base_path=$2
+    rm $OPT $base_path/hooks/$hook
+}
+
+${FUNC} 'pre-commit' '.git'

--- a/git-hooks/pre-commit.sh
+++ b/git-hooks/pre-commit.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Pre-commit hook that verifies if all files containing 'vault' in the name
+# are encrypted.
+# If not, commit will fail with an error message
+#
+# File should be .git/hooks/pre-commit and executable
+VAULT_FILE_INCLUDE_PATTERN='(/vault.yml|.*.vault|.*vault.*)$'
+VAULT_FILE_EXCLUDE_PATTERN='^tests|development|^src/commcare_cloud/environment/secrets/backends/ansible_vault/|src/commcare_cloud/manage_commcare_cloud/list_vault_keys.py'
+REQUIRED='ANSIBLE_VAULT'
+
+EXIT_STATUS=0
+wipe="\033[1m\033[0m"
+yellow='\033[1;33m'
+# carriage return hack. Leave it on 2 lines.
+cr='
+'
+for f in $(git diff --cached --name-only | grep -E "$VAULT_FILE_INCLUDE_PATTERN" | grep -E -v "$VAULT_FILE_EXCLUDE_PATTERN")
+do
+  MATCH=`grep -L $REQUIRED $f | head -n 1`
+  if [ -n "${MATCH// }" ] ; then
+    UNENCRYPTED_FILES="$f$cr$UNENCRYPTED_FILES"
+    EXIT_STATUS=1
+  fi
+done
+if [ $EXIT_STATUS = 0 ] ; then
+  exit 0
+else
+  echo '# COMMIT REJECTED'
+  echo '# Looks like unencrypted ansible-vault files are part of the commit:'
+  echo '#'
+  while read -r line; do
+    if [ -n "$line" ]; then
+      echo -e "#\t${yellow}unencrypted:   $line${wipe}"
+    fi
+  done <<< "$UNENCRYPTED_FILES"
+  echo '#'
+  echo "# Please encrypt them with 'ansible-vault encrypt <file>'"
+  echo "#   (or force the commit with '--no-verify')."
+  exit $EXIT_STATUS
+fi


### PR DESCRIPTION
Adds a pre-commit hook to prevent accidentally committing unencrypted vault files.

This is the same script that we use in CommCare Cloud.

To install, run
```bash
$ git-hooks/install.sh
```

I have tested this locally.
