### PR TITLE
accept content type application/json in celery tasks

### DIFF
--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -75,7 +75,7 @@ RESULTS_BACKEND = RedisCache(
 
 
 class CeleryConfig(object):
-    accept_content = ['pickle']
+    accept_content = ['application/json']
     broker_url = _REDIS_URL
     imports = (
         'superset.sql_lab',

--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -75,7 +75,7 @@ RESULTS_BACKEND = RedisCache(
 
 
 class CeleryConfig(object):
-    accept_content = ['application/json']
+    accept_content = ['pickle', 'application/json']
     broker_url = _REDIS_URL
     imports = (
         'superset.sql_lab',


### PR DESCRIPTION
The change in this PR that sets `accept_content` to `pickle` introduced a bug in CCA celery tasks. The bug log states
`kombu.exceptions.ContentDisallowed: Refusing to deserialize untrusted content of type json (application/json`.

Prior to this PR, there was no value explicitly set hence the `accept_content` falls to the [default value](https://docs.celeryq.dev/en/latest/userguide/configuration.html#accept-content) which is `application/json`. 

This change updates the value from `pickle` to `application/json`. 
