### PR TITLE
Bump gunicorn workers to 40

### DIFF
--- a/roles/commcare_analytics/defaults/main.yml
+++ b/roles/commcare_analytics/defaults/main.yml
@@ -69,7 +69,7 @@ superset_environment:
   FLASK_APP: superset
   SUPERSET_CONFIG_PATH: '{{ superset_project_dir }}/superset_config.py'
 
-gunicorn_num_workers: 20
+gunicorn_num_workers: 40
 gunicorn_max_requests: 0
 gunicorn_reload_workers: true
 gunicorn_timeout_seconds: 900


### PR DESCRIPTION
In order to server more requests coming from HQ for repeaters, bump the number of workers.
This change was made on production and the machine was able to keep up with the load.