### PR TITLE
Add datadog to ansible

### DIFF
--- a/environments/example/vars.yml
+++ b/environments/example/vars.yml
@@ -11,6 +11,11 @@ superset_db_name: superset_meta
 oauth2_db_name: superset_oauth2
 cchq_db_name: superset_cchq_data
 
+datadog:
+  enabled: false
+  hostname: example-env
+  site: us5.datadoghq.com
+
 project_timezone: 'Asia/Kolkata'
 
 # Superset Auth settings

--- a/environments/example/vault.yml
+++ b/environments/example/vault.yml
@@ -12,3 +12,5 @@ vault_superset_fernet_key: fernet-key
 
 vault_oauth_client_id: client_id
 vault_oauth_client_secret: secret
+
+datadog_api_key: ""

--- a/environments/example/vault.yml
+++ b/environments/example/vault.yml
@@ -13,4 +13,5 @@ vault_superset_fernet_key: fernet-key
 vault_oauth_client_id: client_id
 vault_oauth_client_secret: secret
 
+superset_admin_password: ""
 datadog_api_key: ""

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,8 @@
 ---
-- src: git+https://github.com/nickhammond/ansible-logrotate.git
-  version: v0.0.5
-  name: ansible-logrotate
+collections:
+  - name: datadog.dd
+
+roles:
+  - src: git+https://github.com/nickhammond/ansible-logrotate.git
+    version: v0.0.5
+    name: ansible-logrotate

--- a/roles/commcare_analytics/tasks/datadog.yml
+++ b/roles/commcare_analytics/tasks/datadog.yml
@@ -1,15 +1,25 @@
 ---
 
-- name: skipping install datadog agent
-  debug:
-    msg: "Skipping datadog because datadog_api_key is not set in the vault.yml file"
-  when: datadog_api_key is undefined
-  tags: datadog
-
 - name: install datadog agent
   import_role:
     name: datadog.dd.agent
   vars:
     datadog_api_key: "{{ datadog_api_key }}"
-  when: datadog_api_key is defined
+  when: datadog.enabled
+  tags: datadog
+
+- name: update datadog configuration
+  become: true
+  become_user: dd-agent
+  blockinfile:
+    path: /etc/datadog-agent/datadog.yaml
+    block: |
+      site: {{ datadog.site }}
+      hostname: {{ datadog.hostname }}
+  tags: datadog
+
+- name: Restart Datadog service
+  ansible.builtin.service:
+    name: datadog-agent
+    state: restarted
   tags: datadog

--- a/roles/commcare_analytics/tasks/datadog.yml
+++ b/roles/commcare_analytics/tasks/datadog.yml
@@ -1,0 +1,15 @@
+---
+
+- name: skipping install datadog agent
+  debug:
+    msg: "Skipping datadog because datadog_api_key is not set in the vault.yml file"
+  when: datadog_api_key is undefined
+  tags: datadog
+
+- name: install datadog agent
+  import_role:
+    name: datadog.dd.agent
+  vars:
+    datadog_api_key: "{{ datadog_api_key }}"
+  when: datadog_api_key is defined
+  tags: datadog

--- a/roles/commcare_analytics/tasks/main.yml
+++ b/roles/commcare_analytics/tasks/main.yml
@@ -107,3 +107,6 @@
 
 - include_tasks: redis.yml
   tags: redis
+
+- include_tasks: datadog.yml
+  tags: datadog


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-3828)

This PR extends ansible to install and configure datadog on install.

The ansible task has been tested with the install process on AWS