### PR TITLE
Drop celery log level

### DIFF
--- a/roles/commcare_analytics/templates/superset/celery_default_start_script.j2
+++ b/roles/commcare_analytics/templates/superset/celery_default_start_script.j2
@@ -13,7 +13,7 @@ echo "Starting {{ app_name }}_celery_default as `whoami`"
 exec celery --app superset.tasks.celery_app:app  \
     worker \
     -n worker1@%h \
-    --loglevel DEBUG \
+    --loglevel INFO \
     --logfile {{ log_dir }}/celery.log \
     -Q celery \
     --concurrency 10 \


### PR DESCRIPTION
to avoid sensitive information from getting leaked in the logs