### PR TITLE
override default expiry time for client credentials grant

### DIFF
--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -36,6 +36,10 @@ OAUTH_PROVIDERS = [
     }
 ]
 
+OAUTH2_TOKEN_EXPIRES_IN = {
+    'client_credentials': 3600 # seconds; override default 86400 which is 10 day to 1 hour
+}
+
 # Will allow user self registration, allowing to create Flask users from Authorized User
 AUTH_USER_REGISTRATION = True
 


### PR DESCRIPTION
This overrides the default expiry time for client credentials grant being used for data source repeaters setup to 1 hour instead of the default 1 day. 