### PR TITLE
Update workers for machine capacity

### DIFF
--- a/roles/commcare_analytics/defaults/main.yml
+++ b/roles/commcare_analytics/defaults/main.yml
@@ -69,7 +69,7 @@ superset_environment:
   FLASK_APP: superset
   SUPERSET_CONFIG_PATH: '{{ superset_project_dir }}/superset_config.py'
 
-gunicorn_num_workers: 20
+gunicorn_num_workers: 32
 gunicorn_max_requests: 0
 gunicorn_reload_workers: true
 gunicorn_timeout_seconds: 900

--- a/roles/commcare_analytics/templates/superset/celery_default_start_script.j2
+++ b/roles/commcare_analytics/templates/superset/celery_default_start_script.j2
@@ -16,5 +16,5 @@ exec celery --app superset.tasks.celery_app:app  \
     --loglevel INFO \
     --logfile {{ log_dir }}/celery.log \
     -Q celery \
-    --concurrency 10 \
+    --concurrency 5 \
     -B


### PR DESCRIPTION
This PR updates
1. gunicorn workers to 32 to scale up for requests from HQ repeaters which seems the max number for the production machine. These workers don't take much resources so it should be fine for staging as well.
2. celery workers to 5 from 10. Celery worker takes quite some CPU and was pushing production machine CPU's to full capacity each time parallel requests were received from repeaters with each request queuing a task for celery. So, brought that down to 5 since celery can always catch up with tasks.