### PR TITLE
Add dogstatsd to Datadog config

### DIFF
--- a/roles/commcare_analytics/tasks/datadog.yml
+++ b/roles/commcare_analytics/tasks/datadog.yml
@@ -16,6 +16,8 @@
     block: |
       site: {{ datadog.site }}
       hostname: {{ datadog.hostname }}
+      use_dogstatsd: true
+      dogstatsd_port: 8125
   tags: datadog
 
 - name: Restart Datadog service


### PR DESCRIPTION
This change is to be used in conjunction with Zandre's changes to install ddtrace and statsd packages.
