### PR TITLE
Add Config for RedisDB Datadog Monitoring

### DIFF
--- a/roles/commcare_analytics/tasks/datadog.yml
+++ b/roles/commcare_analytics/tasks/datadog.yml
@@ -18,6 +18,15 @@
       hostname: {{ datadog.hostname }}
   tags: datadog
 
+- name: Add redisdb config
+  template:
+    src: "datadog/redisdb.yaml.j2"
+    dest: "/etc/datadog-agent/conf.d/redisdb.d/conf.yaml"
+    owner: dd-agent
+    group: dd-agent
+    mode: 0640
+  tags: datadog
+
 - name: Restart Datadog service
   ansible.builtin.service:
     name: datadog-agent

--- a/roles/commcare_analytics/templates/datadog/redisdb.yaml.j2
+++ b/roles/commcare_analytics/templates/datadog/redisdb.yaml.j2
@@ -1,0 +1,7 @@
+init_config:
+
+instances:
+  - host: localhost
+    port: 6379
+    tags:
+      - instance: {{ datadog.hostname }}


### PR DESCRIPTION
Adds a config file for RedisDB in the Datadog directory, which is necessary for enabling redis monitoring.

These instructions come from [this](https://www.datadoghq.com/blog/monitor-redis-using-datadog/) Datadog documentation.