### PR TITLE
Add server env config for DataDog

### DIFF
--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -157,3 +157,6 @@ TALISMAN_CONFIG = {
 
 USER_DOMAIN_ROLE_EXPIRY = 60 # minutes
 SKIP_DATASET_CHANGE_FOR_DOMAINS = []
+
+# Used for datadog monitoring
+SERVER_ENVIRONMENT = "{{ datadog.hostname }}"  # staging, production, etc.


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-4106). Relates to [this CCA change](https://github.com/dimagi/commcare-analytics/pull/100).

This PR makes sure the `SERVER_ENVIRONMENT` setting is set up in the `super_config.py` file during installation.