### PR TITLE
Add bucket policy to remove old backups

### DIFF
--- a/environments/example/vars.yml
+++ b/environments/example/vars.yml
@@ -18,6 +18,7 @@ datadog:
 
 project_timezone: 'Asia/Kolkata'
 enable_postgresql_backup: false
+postgresql_backup_retention_days: 7
 
 # Superset Auth settings
 oauth_creds:

--- a/roles/commcare_analytics/tasks/pg_backup.yml
+++ b/roles/commcare_analytics/tasks/pg_backup.yml
@@ -37,3 +37,20 @@
     user: "{{ postgresql_user }}"
   tags:
     - postgres_backup
+
+- name: Adding backup policy configuration
+  become: yes
+  template:
+    src: s3_bucket_policy.json.j2
+    dest: /usr/local/bin/s3_bucket_policy.json
+    group: "{{ postgresql_user }}"
+    owner: "{{ postgresql_user }}"
+    mode: 0700
+  tags:
+    - postgres_backup
+
+- name: Create S3 bucket lifecycle policy
+  become: yes
+  command: "aws s3api put-bucket-lifecycle-configuration --bucket {{ s3_bucket_name }} --policy file:///usr/local/bin/s3_bucket_policy.json"
+  tags:
+    - postgres_backup

--- a/roles/commcare_analytics/templates/s3_bucket_policy.json.j2
+++ b/roles/commcare_analytics/templates/s3_bucket_policy.json.j2
@@ -4,7 +4,7 @@
             "Status": "Enabled",
             "Prefix": "postgres_backup",
             "Expiration": {
-                "Days": 7
+                "Days": "{{ postgresql_backup_retention_days }}"
             },
             "ID": "DeleteExpiredPostgresBackups"
         }

--- a/roles/commcare_analytics/templates/s3_bucket_policy.json.j2
+++ b/roles/commcare_analytics/templates/s3_bucket_policy.json.j2
@@ -1,0 +1,12 @@
+{
+    "Rules": [
+        {
+            "Status": "Enabled",
+            "Prefix": "postgres_backup",
+            "Expiration": {
+                "Days": 7
+            },
+            "ID": "DeleteExpiredPostgresBackups"
+        }
+    ]
+}


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-4076)

This PR adds steps to the ansible script to set up an S3 lifecycle policy on the backup bucket which will remove objects in the bucket ([prefixed with "postgres_backup"](https://github.com/dimagi/commcare-analytics-ansible/blob/ff5068d955cc2d9bd2a1d5a5ce51d12d540cc3a3/roles/commcare_analytics/templates/s3_bucket_policy.json.j2#L5)) after 7 days (governed by `postgresql_backup_retention_days`).

It's does not seem possible to simply specify an expiry on the `put-object` command. There is a `--retention` option, but that (IMO misleadingly) only means users won't be able to remove the object before the given date. What we want is not an object lock, but an object delete, and it seems like this can only be done through the bucket lifecycle policy.  

[Read more about put-bucket-policy](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-policy.html).

Please note, this should still be tested.