### PR TITLE
Append backup script to remove all by N previous backups

### DIFF
--- a/environments/example/vars.yml
+++ b/environments/example/vars.yml
@@ -18,6 +18,7 @@ datadog:
 
 project_timezone: 'Asia/Kolkata'
 enable_postgresql_backup: false
+postgresql_backups_to_keep: 5  # 0 will ignore this setting
 
 # Superset Auth settings
 oauth_creds:

--- a/roles/commcare_analytics/templates/create_postgres_dump.sh.j2
+++ b/roles/commcare_analytics/templates/create_postgres_dump.sh.j2
@@ -53,4 +53,26 @@ if [[ $? -ne 0 ]] ; then
     exit 1
 fi
 
+N_BACKUPS="{{ postgresql_backups_to_keep }}"
+if [ "$N_BACKUPS" -gt 0 ]; then
+    log "Checking for backups to remove";
+    # List objects matching the pattern and capture the result in a variable
+    objects_to_delete=$(aws s3api list-objects --bucket "{{ secrets.s3_bucket }}" --query "Contents[?starts_with(Key, 'postgres_backup_')].[Key, LastModified]" --output text | \
+      sort -k2 | \
+      head -n -"{{ postgresql_backups_to_keep }}"
+
+    # Check if there are any objects to delete
+    if [ -n "$objects_to_delete" ]; then
+      echo "Deleting objects"
+      # Format the object keys into the necessary JSON structure and delete the objects
+      echo "$objects_to_delete" | \
+        awk '{print "{\"Key\":\"" $1 "\"}"}' | \
+        paste -sd, | \
+        sed 's/^/{"Objects":[/;s/$/]}/' | \
+        aws s3api delete-objects --bucket "{{ secrets.s3_bucket }}" --delete file:///dev/stdin
+    else
+      echo "No objects found to delete."
+    fi
+fi
+
 exit 0

--- a/roles/commcare_analytics/templates/create_postgres_dump.sh.j2
+++ b/roles/commcare_analytics/templates/create_postgres_dump.sh.j2
@@ -59,7 +59,7 @@ if [ "$N_BACKUPS" -gt 0 ]; then
     # List objects matching the pattern and capture the result in a variable
     objects_to_delete=$(aws s3api list-objects --bucket "{{ secrets.s3_bucket }}" --query "Contents[?starts_with(Key, 'postgres_backup_')].[Key, LastModified]" --output text | \
       sort -k2 | \
-      head -n -"{{ postgresql_backups_to_keep }}"
+      head -n -$N_BACKUPS)
 
     # Check if there are any objects to delete
     if [ -n "$objects_to_delete" ]; then


### PR DESCRIPTION
Relates to [this PR](https://github.com/dimagi/commcare-analytics-ansible/pull/49).

[Ticket](https://dimagi.atlassian.net/browse/SC-4076)

This PR appends to the backup script to make sure to only keep the last N backup objects on S3, as based on the script found in [this comment](https://dimagi.atlassian.net/browse/SC-3941?focusedCommentId=362070). 