### PR TITLE
Fix heading spacing in docs

### DIFF
--- a/docs/system-administration.rst
+++ b/docs/system-administration.rst
@@ -40,8 +40,8 @@ project-specific environment variables. ::
 ..
     TODO: Make this true:
 
-    Deploying Changes
-    ^^^^^^^^^^^^^^^^^
+Deploying Changes
+^^^^^^^^^^^^^^^^^
 
     You may wish to deploy updates to the server, for example to pull the
     latest changes from the CommCare analytics code.


### PR DESCRIPTION
I noticed that a section did not show in the .rst document preview, so this PR simply fixes the spacing to make it appear.