### PR TITLE
Error Handling for False-Positive SQLLab Exception

### DIFF
--- a/roles/commcare_analytics/templates/superset/superset_config.py.j2
+++ b/roles/commcare_analytics/templates/superset/superset_config.py.j2
@@ -1,5 +1,6 @@
 from cachelib.redis import RedisCache
 from celery.schedules import crontab
+from flask import Flask, request
 from flask_appbuilder.security.manager import AUTH_OAUTH, AUTH_DB
 
 from hq_superset import flask_app_mutator, oauth
@@ -160,3 +161,19 @@ SKIP_DATASET_CHANGE_FOR_DOMAINS = []
 
 # Used for datadog monitoring
 SERVER_ENVIRONMENT = "{{ datadog.hostname }}"  # staging, production, etc.
+
+def FLASK_APP_MUTATOR(app: Flask):
+    app.after_request(error_check_after_req)
+
+def error_check_after_req(response_obj):
+    """
+    This gets used by the Flask app's after_request hook to check for
+    endpoints that return false-positive 500 errors and change them to
+    a more appropriate 400 error.
+    """
+    if (
+        request.path.startswith("/api/v1/sqllab/execute/")
+        and response_obj.status_code == 500
+    ):
+        response_obj.status_code = 400    
+    return response_obj


### PR DESCRIPTION
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4284).

This PR introduces a small change to the superset_config file in which a hook is added to the after_request handler for the Superset Flask application. This hook essentially checks for 500 requests coming from the `/api/v1/sqllab/execute/` endpoint and changes them to 400.

The reason for this change is that SQLLab allows for creating invalid queries (e.g. accessing a table that doesn't exist). When this happens, Superset simply throws an unhandled 500 exception which then gets raised as a false-positive 500 request on Datadog. Changing the status code to 400 more appropriately flags it as simply an invalid request rather than an exception.

Please note, that there exists a related PR in the commcare-analytics repo to add the same to the `superset_config_example.py` file. The PR can be accessed [here](https://github.com/dimagi/commcare-analytics/pull/118).