### PR TITLE
Add rate limiting via nginx

### DIFF
--- a/roles/commcare_analytics/templates/nginx/superset_nginx_without_ssl_config.j2
+++ b/roles/commcare_analytics/templates/nginx/superset_nginx_without_ssl_config.j2
@@ -15,6 +15,8 @@ log_format combined_with_timing '$remote_addr - $remote_user [$time_local] '
                                 '"$request" $request_time $status $bytes_sent '
                                 '"$http_referer" "$http_user_agent"';
 
+limit_req_zone $binary_remote_addr zone=ip_limited:10m rate=50r/s;
+
 server {
   # Serve content
   server_name {{ superset_public_host }};
@@ -22,6 +24,8 @@ server {
   listen [::]:80;
 
   client_max_body_size 4G;
+
+  limit_req zone=ip_limited burst=100 nodelay;
 
   access_log {{ nginx_access_log_file }} combined_with_timing;
   error_log {{ nginx_error_log_file }};


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SC-3873

This adds rate limiting to CommCare Analytics as a safety measure.

Considered the documentation in https://blog.nginx.org/blog/rate-limiting-nginx and referred to how [this was done](https://github.com/dimagi/commcare-cloud/blob/046c5d5e6007efef46e56c0f3335dd71854d63b2/src/commcare_cloud/ansible/roles/nginx/templates/site.j2#L43) in commcare-cloud for an older environment.

Looking at the requests received in Datadog nginx metrics for last 3 months, I see a peak at [roughly 400 requests per 10 seconds](https://us5.datadoghq.com/dashboard/hcz-qfr-ehu/system-vitals?fromUser=false&fullscreen_end_ts=1741887221315&fullscreen_paused=true&fullscreen_refresh_mode=paused&fullscreen_section=overview&fullscreen_start_ts=1741887161315&fullscreen_widget=6139778504102584&refresh_mode=sliding&from_ts=1742197736396&to_ts=1742284136396&live=true).
Keeping that in mind I have set the maximum number of requests to 50 requests per second.

Additionally, setting burst as 100, which implies that nginx will maintain a queue of 100 in case more than 50 are received.
Along with "nodelay" which is a way to forward the extra requests to nginx without any delay, waiting for their time to come but still counting them as requests being sent for metrics and holding off new requests.
Using "burst" with nodelay is the recommend approach.

Tested that this does not cause any issues on staging when added to superset.conf file under nginx's sites available/enabled.
Tested the limit on staging by lowering the limit to 5 req/m and lowering the burst value to 8 that requests were being held off and responded
```
2025/03/18 14:47:45 [error] 176984#176984: *50598 limiting requests, excess: 1.981 by zone "ip_limited", client: 152.58.121.61, server: commcare-analytics-staging.dimagi.com, request: "GET /static/assets/images/favicon.png HTTP/1.1", host: "commcare-analytics-staging.dimagi.com", referrer: "https://commcare-analytics-staging.dimagi.com/login/"
```
and requests were significantly longer
```
152.58.121.61 - - [18/Mar/2025:14:54:29 +0000] "GET /static/assets/8755.b325fab1a4b5f24a84fc.entry.js HTTP/1.1" 72.905 200 387987 "https://commcare-analytics-staging.dimagi.com/superset/welcome/" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:136.0) Gecko/20100101 Firefox/136.0"
152.58.121.61 - - [18/Mar/2025:14:54:40 +0000] "GET /static/assets/5640.10418d29798f90ad356a.entry.js HTTP/1.1" 68.535 200 13879 "https://commcare-analytics-staging.dimagi.com/superset/welcome/" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:136.0) Gecko/20100101 Firefox/136.0"
```
which went back to normal when the limits were restored to that of this PR.

Side note: Turns out nginx can only be configured during setup before applying ssl using the ansible repo. Post it, nginx can only modified manually.
Did confirm though that the settings are applied okay if ssl has not been enabled yet.

Yet to be applied on production, post review.